### PR TITLE
Upgrade sourcegraph and set up SSO (closes #3)

### DIFF
--- a/kubernetes/secrets/config/code-hosts.json.erb
+++ b/kubernetes/secrets/config/code-hosts.json.erb
@@ -1,0 +1,19 @@
+{
+  "GITHUB": [
+    {
+      "url": "https://github.com",
+      "token": "<%= github_token %>",
+      "repositoryQuery": [
+        "org:ocf is:public archived:false"
+      ],
+      "exclude": [
+        {
+          "name": "ocf/apache2-suexec-ocf"
+        },
+        {
+          "name": "ocf/octocatalog-diff"
+        }
+      ]
+    }
+  ]
+}

--- a/kubernetes/secrets/config/site.json.erb
+++ b/kubernetes/secrets/config/site.json.erb
@@ -1,0 +1,19 @@
+{
+  "externalURL": "https://sourcegraph.ocf.berkeley.edu",
+
+  "auth.providers": [
+    {
+      "type": "builtin"
+    },
+    {
+      "type": "openidconnect",
+      "displayName": "OCF Auth",
+      "issuer": "https://auth.ocf.berkeley.edu/auth/realms/ocf",
+      "clientID": "sourcegraph",
+      "clientSecret": "<%= auth_client_secret %>"
+    }
+  ],
+
+  "disablePublicRepoRedirects": true,
+  "search.index.enabled": true
+}

--- a/kubernetes/sourcegraph.yaml.erb
+++ b/kubernetes/sourcegraph.yaml.erb
@@ -1,41 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: codeintel-python-service
-spec:
-  selector:
-    app: sourcegraph
-  ports:
-    - port: 2087
-      targetPort: 2087
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: codeinel-python-deployment
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: sourcegraph
-  template:
-    metadata:
-      labels:
-        app: sourcegraph
-    spec:
-      containers:
-        - name: codeintel-python
-          image: sourcegraph/codeintel-python:18892_2018-07-27_ddc9943
-          resources:
-            limits:
-              memory: 512Mi
-              cpu: 1
-          ports:
-            - containerPort: 2087
----
-apiVersion: v1
-kind: Service
-metadata:
   name: sourcegraph-service
 spec:
   selector:
@@ -62,7 +27,7 @@ spec:
     spec:
       containers:
         - name: sourcegraph
-          image: "sourcegraph/server:3.0.1"
+          image: "sourcegraph/server:3.16.1"
           resources:
             limits:
               memory: 2Gi
@@ -75,8 +40,10 @@ spec:
             - name: sourcegraph-data
               mountPath: /var/opt/sourcegraph
           envFrom:
+            - configMapRef:
+                name: sourcegraph-config-vars
             - secretRef:
-                name: sourcegraph-secret
+                name: sourcegraph-db-password
           livenessProbe:
             httpGet:
               path: /
@@ -92,27 +59,36 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 5
       volumes:
-        - name: sourcegraph-secrets
-          hostPath:
-            path: /opt/share/kubernetes/secrets/sourcegraph
-            type: Directory
+        - name: sourcegraph-config
+          secret:
+            secretName: config
         - name: sourcegraph-data
           hostPath:
             path: /opt/share/kubernetes/sourcegraph
             type: Directory
 ---
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
-  name: sourcegraph-secret
-type: Opaque
-stringData:
+  name: sourcegraph-config-vars
+data:
+  # Load data from config files, don't allow them to be edited through the UI
+  SITE_CONFIG_FILE: "/etc/sourcegraph/site.json"
+  EXTSVC_CONFIG_FILE: "/etc/sourcegraph/code-hosts.json"
+  # Load more DB config for things that are not secrets
   PGPORT: "5432"
   PGHOST: "postgres.ocf.berkeley.edu"
   PGUSER: "ocfsourcegraph"
-  PGPASSWORD: "<%= sourcegraph_pgpassword %>"
   PGDATABASE: "ocfsourcegraph"
   PGSSLMODE: "require"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sourcegraph-db-password
+type: Opaque
+data:
+  PGPASSWORD: "<%= sourcegraph_pgpassword %>"
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/kubernetes/sourcegraph.yaml.erb
+++ b/kubernetes/sourcegraph.yaml.erb
@@ -35,7 +35,7 @@ spec:
           ports:
             - containerPort: 7080
           volumeMounts:
-            - name: sourcegraph-secrets
+            - name: sourcegraph-config
               mountPath: /etc/sourcegraph
             - name: sourcegraph-data
               mountPath: /var/opt/sourcegraph

--- a/kubernetes/sourcegraph.yaml.erb
+++ b/kubernetes/sourcegraph.yaml.erb
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: sourcegraph
-          image: "sourcegraph/server:3.16.1"
+          image: "sourcegraph/server:3.18.0"
           resources:
             limits:
               memory: 2Gi


### PR DESCRIPTION
I tested this locally and it all worked, but that was without the kubernetes setup and with secrets in the config files. I'm pretty confident the sourcegraph side of things with this will work (although it'll need to do some DB upgrades and stuff), but the kubernetes templating and all that I'm not so confident in.

I've tried an upgrade to 3.8 before here, and it messed up the DB state for the running version of sourcegraph so to actually test an upgrade with kubernetes I think I'd need to make a full copy of the DB and try with that instead. I'm tempted to just yolo it instead given we should be able to just blow away any state if needed :)

After the migration here is done, I'd like to remove the builtin auth method so that the redirect to keycloak is quick and takes effect without having to click a button, but I think it'd probably be better if it happens in a second commit/review.